### PR TITLE
Initialize Game.board with the input Cells

### DIFF
--- a/starterAIs/starter.cs
+++ b/starterAIs/starter.cs
@@ -138,6 +138,12 @@ class Player
             int neigh3 = int.Parse(inputs[5]);
             int neigh4 = int.Parse(inputs[6]);
             int neigh5 = int.Parse(inputs[7]);
+            Cell cell = new Cell(
+                index, 
+                richness, 
+                new int[] {neigh0, neigh1, neigh2, neigh3, neigh4, neigh5}
+            );
+            game.board.Add(cell);
         }
 
         // game loop


### PR DESCRIPTION
All other Game properties are initialized except for the `board`. Don't know if this was intentional or accidentally left off. But this PR adds each of the cells to the game board.