### PR TITLE
translation error in french

### DIFF
--- a/config/statement_fr.html.tpl
+++ b/config/statement_fr.html.tpl
@@ -247,7 +247,7 @@
               <img src="https://static.codingame.com/servlet/fileservlet?id=61699004461164" />
               <div class="legend">
                 <div class="description">
-                  L'arbre moyen projette une ombre qui n'est <b>pas menaçante</b> sur l'arbre petit.
+                  L'arbre moyen projette une ombre qui n'est <b>pas menaçante</b> sur l'arbre grand.
                 </div>
               </div>
             </div>

--- a/config/statement_fr.html.tpl
+++ b/config/statement_fr.html.tpl
@@ -209,7 +209,7 @@
         <ul>
           <li>Les arbres de taille <const>1</const> projettent une ombre sur <const>1</const> case.</li>
           <li>Les arbres de taille <const>2</const> projettent une ombre sur <const>2</const> cases.</li>
-          <li>Les arbres de taille <const>1</const> projettent une ombre sur <const>3</const> cases.</li>
+          <li>Les arbres de taille <const>3</const> projettent une ombre sur <const>3</const> cases.</li>
         </ul>
         </div>
 


### PR DESCRIPTION
Hi, 

In English, it's `The medium tree casts a shadow that is <b>not spooky</b> on the tall tree.` 
So, according to me, in french, it should be `grand`
 
-- 
I'm loving Trees, Thanks for this challenge :palm_tree: 