### PR TITLE
fix: ruby starter

### DIFF
--- a/starterAIs/starter.rb
+++ b/starterAIs/starter.rb
@@ -26,7 +26,7 @@ class Action
     if (parts[0] == WAIT)
       return Action.new(WAIT)
     end
-    if (parts[1] == SEED)
+    if (parts[0] == SEED)
       return Action.new(SEED, parts[2].to_i, parts[1].to_i)
     end
     return Action.new(parts[0], parts[1].to_i)


### PR DESCRIPTION
There is a typo in the `Action.parse` method of the ruby starter file preventing correct parsing of "SEED" actions.


This PR fixes it